### PR TITLE
Update makelist.py

### DIFF
--- a/src/build/makelist.py
+++ b/src/build/makelist.py
@@ -28,7 +28,7 @@ def parse_file(srcfile):
                 if c==13 and line[srcptr]==10:
                     srcptr+=1
                 continue
-            if c==' ':
+            if c<=' ' or c==160: // continues on tab, form-feed, (others), space, and non-breakable space.
                 continue
             if in_comment==1 and c=='*' and line[srcptr]=='/' :
                 srcptr+=1

--- a/src/build/makelist.py
+++ b/src/build/makelist.py
@@ -28,7 +28,7 @@ def parse_file(srcfile):
                 if c==13 and line[srcptr]==10:
                     srcptr+=1
                 continue
-            if c<=' ' or c==160: // continues on tab, form-feed, (others), space, and non-breakable space.
+            if c<=' ' or c==160: # continues on tab, form-feed, (others), space, and non-breakable space.
                 continue
             if in_comment==1 and c=='*' and line[srcptr]=='/' :
                 srcptr+=1


### PR DESCRIPTION
This addresses the issue of the game lists parser tripping up on tab characters.  This fix should also take care of any unprintable characters between ASCII 1 and ASCII 32 (Space), plus the unbreakable space character.  It's unlikely anyone would intentionally put any oddball characters in, but this code should be more resilient that the original.

I think it is safe to continue on all character codes less than space, because the special case handling of CRLF / LF is already handled further up in the compound IF statement.

Some previous comments here: https://github.com/mamedev/mame/commit/4d3ae8b5aeff6f4a396051dd8467077a3c087929

Sorry about the bad comment syntax on the first go.